### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/112/586/528/9/1125865289.geojson
+++ b/data/112/586/528/9/1125865289.geojson
@@ -25,6 +25,9 @@
     "name:afr_x_preferred":[
         "Salazie"
     ],
+    "name:ara_x_preferred":[
+        "\u0633\u0627\u0644\u0627\u0632\u064a"
+    ],
     "name:arg_x_preferred":[
         "Salazie"
     ],
@@ -48,6 +51,9 @@
     ],
     "name:ces_x_preferred":[
         "Salazie"
+    ],
+    "name:che_x_preferred":[
+        "\u0421\u0430\u043b\u0430\u0437\u0438"
     ],
     "name:cos_x_preferred":[
         "Salazie"
@@ -157,6 +163,9 @@
     "name:lit_x_preferred":[
         "Salazie"
     ],
+    "name:lld_x_preferred":[
+        "Salazie"
+    ],
     "name:ltz_x_preferred":[
         "Salazie"
     ],
@@ -241,6 +250,9 @@
     "name:swe_x_preferred":[
         "Salazie"
     ],
+    "name:tat_x_preferred":[
+        "\u0421\u0430\u043b\u0430\u0437\u0438"
+    ],
     "name:tur_x_preferred":[
         "Salazie"
     ],
@@ -273,6 +285,9 @@
     ],
     "name:wol_x_preferred":[
         "Salazie"
+    ],
+    "name:zho_x_preferred":[
+        "\u8428\u62c9\u6d4e"
     ],
     "name:zul_x_preferred":[
         "Salazie"
@@ -316,7 +331,7 @@
         }
     ],
     "wof:id":1125865289,
-    "wof:lastmodified":1566609741,
+    "wof:lastmodified":1690857385,
     "wof:name":"Salazie",
     "wof:parent_id":85671199,
     "wof:placetype":"locality",

--- a/data/112/595/261/5/1125952615.geojson
+++ b/data/112/595/261/5/1125952615.geojson
@@ -52,6 +52,12 @@
     "name:ces_x_preferred":[
         "Saint-Louis"
     ],
+    "name:che_x_preferred":[
+        "\u0421\u0435\u043d-\u041b\u0443\u0438"
+    ],
+    "name:chv_x_preferred":[
+        "\u0421\u0435\u043d-\u041b\u0443\u0438"
+    ],
     "name:cos_x_preferred":[
         "Saint-Louis"
     ],
@@ -63,6 +69,9 @@
     ],
     "name:deu_x_preferred":[
         "Saint-Louis"
+    ],
+    "name:ell_x_preferred":[
+        "\u03a3\u03b1\u03b9\u03bd-\u039b\u03bf\u03c5\u03af"
     ],
     "name:eng_x_preferred":[
         "Saint-Louis"
@@ -154,6 +163,9 @@
     "name:kon_x_preferred":[
         "Saint-Louis"
     ],
+    "name:kor_x_preferred":[
+        "\uc0dd\ub8e8\uc774"
+    ],
     "name:lav_x_preferred":[
         "Saint-Louis"
     ],
@@ -164,6 +176,9 @@
         "Saint-Louis"
     ],
     "name:lit_x_preferred":[
+        "Saint-Louis"
+    ],
+    "name:lld_x_preferred":[
         "Saint-Louis"
     ],
     "name:ltz_x_preferred":[
@@ -301,6 +316,9 @@
     "name:yue_x_preferred":[
         "\u8056\u8def\u6613\u65af"
     ],
+    "name:zho_x_preferred":[
+        "\u5723\u8def\u6613"
+    ],
     "name:zul_x_preferred":[
         "Saint-Louis"
     ],
@@ -359,7 +377,7 @@
         }
     ],
     "wof:id":1125952615,
-    "wof:lastmodified":1636503227,
+    "wof:lastmodified":1690857385,
     "wof:name":"Saint-Louis",
     "wof:parent_id":85671199,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.